### PR TITLE
修复论文列表与移动端样式问题，完善用户须知交互并清理 Cypress 示例文件

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,9 @@ supabase/.env
 
 # Claude
 .claude/
+
+# Cypress generated examples
+cypress/e2e/1-getting-started/
+cypress/e2e/2-advanced-examples/
+cypress/fixtures/example.json
+cypress/support/e2e.ts

--- a/src/components/layout/CookieConsent.test.tsx
+++ b/src/components/layout/CookieConsent.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { CookieConsent } from './CookieConsent';
+
+function renderCookieConsent(initialEntry: string) {
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <Routes>
+        <Route
+          path="*"
+          element={
+            <>
+              <div>Page content</div>
+              <CookieConsent />
+            </>
+          }
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('CookieConsent', () => {
+  it('shows the consent modal and locks scrolling on regular pages', () => {
+    renderCookieConsent('/');
+
+    expect(screen.getByText('USER NOTICE / 用户须知')).toBeInTheDocument();
+    expect(document.body.style.overflow).toBe('hidden');
+    expect(screen.getByRole('link', { name: '《用户协议》' })).toHaveAttribute('target', '_blank');
+    expect(screen.getByRole('link', { name: '《隐私政策》' })).toHaveAttribute('target', '_blank');
+  });
+
+  it('does not block legal pages and keeps scrolling enabled', () => {
+    renderCookieConsent('/terms');
+
+    expect(screen.queryByText('USER NOTICE / 用户须知')).not.toBeInTheDocument();
+    expect(screen.getByText('Page content')).toBeInTheDocument();
+    expect(document.body.style.overflow).toBe('unset');
+  });
+
+  it('does not toggle the checkbox when a legal link is clicked', async () => {
+    const user = userEvent.setup();
+
+    renderCookieConsent('/');
+
+    const checkbox = screen.getByRole('checkbox');
+    expect(checkbox).not.toBeChecked();
+
+    await user.click(screen.getByRole('link', { name: '《用户协议》' }));
+
+    expect(checkbox).not.toBeChecked();
+  });
+});

--- a/src/components/layout/CookieConsent.tsx
+++ b/src/components/layout/CookieConsent.tsx
@@ -1,18 +1,37 @@
-import React, { useState, useEffect } from 'react';
-import { Link } from 'react-router-dom';
+import React, { useId, useState, useEffect } from 'react';
+import { Link, useLocation } from 'react-router-dom';
 
 export const CookieConsent: React.FC = () => {
+  const location = useLocation();
+  const consentCheckboxId = useId();
   const [isVisible, setIsVisible] = useState(false);
   const [hasAgreed, setHasAgreed] = useState(false);
+  const [isConsentTextHovered, setIsConsentTextHovered] = useState(false);
+  const isLegalPage = location.pathname === '/terms' || location.pathname === '/privacy';
 
   useEffect(() => {
+    if (isLegalPage) {
+      setIsVisible(false);
+      document.body.style.overflow = 'unset';
+      return () => {
+        document.body.style.overflow = 'unset';
+      };
+    }
+
     const consent = localStorage.getItem('shit_journal_consent');
     if (!consent) {
       setIsVisible(true);
       // 🔒 强制锁死底层页面的滚动，逼迫用户必须处理这个弹窗
       document.body.style.overflow = 'hidden';
+    } else {
+      setIsVisible(false);
+      document.body.style.overflow = 'unset';
     }
-  }, []);
+
+    return () => {
+      document.body.style.overflow = 'unset';
+    };
+  }, [isLegalPage]);
 
   const handleAccept = () => {
     if (!hasAgreed) return;
@@ -22,7 +41,7 @@ export const CookieConsent: React.FC = () => {
     document.body.style.overflow = 'unset';
   };
 
-  if (!isVisible) return null;
+  if (isLegalPage || !isVisible) return null;
 
   return (
     // 🌑 全屏遮罩 + 深度模糊，彻底阻断背景交互
@@ -61,25 +80,57 @@ export const CookieConsent: React.FC = () => {
 
         {/* ⚠️ 强制交互区 */}
         <div className="flex flex-col gap-6">
-          <label className="flex items-start gap-3 cursor-pointer group">
+          <div className="flex items-start gap-3">
             <div className="pt-0.5">
               <input 
+                id={consentCheckboxId}
                 type="checkbox" 
                 checked={hasAgreed}
                 onChange={(e) => setHasAgreed(e.target.checked)}
                 className="w-5 h-5 accent-accent-gold cursor-pointer"
               />
             </div>
-            <div className="text-sm text-charcoal font-bold group-hover:text-accent-gold transition-colors select-none">
-              我已年满 18 周岁，并已仔细阅读且同意遵守本平台的 
-              <Link to="/terms" target="_blank" className="text-accent-gold underline mx-1">《用户协议》</Link> 
-              与 
-              <Link to="/privacy" target="_blank" className="text-accent-gold underline mx-1">《隐私政策》</Link>。
-              <span className="block text-xs text-gray-400 font-normal mt-1">
+            <div className="text-sm text-charcoal font-bold transition-colors">
+              <label
+                htmlFor={consentCheckboxId}
+                onMouseEnter={() => setIsConsentTextHovered(true)}
+                onMouseLeave={() => setIsConsentTextHovered(false)}
+                className={`cursor-pointer select-none ${isConsentTextHovered ? 'text-accent-gold' : ''}`}
+              >
+                我已年满 18 周岁，并已仔细阅读且同意遵守本平台的
+              </label>
+              <Link to="/terms" target="_blank" rel="noreferrer" className="text-accent-gold underline mx-1">
+                《用户协议》
+              </Link>
+              <label
+                htmlFor={consentCheckboxId}
+                onMouseEnter={() => setIsConsentTextHovered(true)}
+                onMouseLeave={() => setIsConsentTextHovered(false)}
+                className={`cursor-pointer select-none ${isConsentTextHovered ? 'text-accent-gold' : ''}`}
+              >
+                与
+              </label>
+              <Link to="/privacy" target="_blank" rel="noreferrer" className="text-accent-gold underline mx-1">
+                《隐私政策》
+              </Link>
+              <label
+                htmlFor={consentCheckboxId}
+                onMouseEnter={() => setIsConsentTextHovered(true)}
+                onMouseLeave={() => setIsConsentTextHovered(false)}
+                className={`cursor-pointer select-none ${isConsentTextHovered ? 'text-accent-gold' : ''}`}
+              >
+                。
+              </label>
+              <label
+                htmlFor={consentCheckboxId}
+                onMouseEnter={() => setIsConsentTextHovered(true)}
+                onMouseLeave={() => setIsConsentTextHovered(false)}
+                className={`block cursor-pointer select-none text-xs font-normal mt-1 ${isConsentTextHovered ? 'text-accent-gold' : 'text-gray-400'}`}
+              >
                 I am over 18 and agree to the Terms of Service and Privacy Policy.
-              </span>
+              </label>
             </div>
-          </label>
+          </div>
 
           <button
             onClick={handleAccept}

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 export const Footer: React.FC = () => (
-  <footer className="bg-black text-white pt-16 pb-12 px-6 lg:px-20 mt-16">
+  <footer className="bg-black text-white pt-16 pb-12 px-6 lg:px-20 mt-12">
     <div className="max-w-7xl mx-auto">
       <div className="grid grid-cols-1 lg:grid-cols-12 gap-12 mb-16">
         <div className="lg:col-span-5">

--- a/src/pages/preprints/PreprintCard.test.tsx
+++ b/src/pages/preprints/PreprintCard.test.tsx
@@ -34,6 +34,7 @@ describe('PreprintCard', () => {
 
     expect(title.className).toContain('line-clamp-2');
     expect(title.className).toContain('[overflow-wrap:anywhere]');
+    expect(title).toHaveAttribute('title', longTitle);
     expect(topic.parentElement?.previousElementSibling).toBe(title);
     expect(screen.getByTitle('构石 / The Stone')).toBeInTheDocument();
     expect(screen.getByText(/4\.82 \/ 5/)).toBeInTheDocument();
@@ -68,6 +69,7 @@ describe('PreprintCard', () => {
 
     expect(title.className).toContain('line-clamp-2');
     expect(title.className).toContain('[overflow-wrap:anywhere]');
+    expect(title).toHaveAttribute('title', longUnbrokenTitle);
     expect(screen.getByText('评价进度 / Progress')).toBeInTheDocument();
     expect(screen.getByText('12 / 30')).toBeInTheDocument();
   });

--- a/src/pages/preprints/PreprintCard.tsx
+++ b/src/pages/preprints/PreprintCard.tsx
@@ -65,6 +65,7 @@ export const PreprintCard: React.FC<{ preprint: PreprintCardProps; zone: Zone }>
 
             <div className="min-w-0 flex-1">
               <h4
+                title={displayTitle}
                 className="font-serif font-bold text-lg text-charcoal group-hover:text-accent-gold transition-colors leading-snug line-clamp-2 [overflow-wrap:anywhere]"
               >
                 {displayTitle}

--- a/src/pages/preprints/PreprintDetailPage.tsx
+++ b/src/pages/preprints/PreprintDetailPage.tsx
@@ -259,7 +259,7 @@ export const PreprintDetailPage: React.FC = () => {
   const coAuthors = Array.isArray(preprint.co_authors) ? preprint.co_authors : [];
 
   return (
-    <div className="max-w-4xl mx-auto px-4 lg:px-8 py-12">
+    <div className="max-w-4xl mx-auto px-2 lg:px-8 py-6">
       <button onClick={() => navigate(-1)} className="text-xs font-bold uppercase tracking-widest text-gray-400 hover:text-accent-gold mb-8">← Back</button>
 
       {/* 管理员操作 */}

--- a/src/pages/preprints/PreprintListPage.test.tsx
+++ b/src/pages/preprints/PreprintListPage.test.tsx
@@ -18,4 +18,23 @@ describe('PreprintListPage', () => {
 
     expect(screen.getByText(/Dr\. Flush/i)).toBeInTheDocument();
   });
+
+  it('uses compact mobile padding for discipline and sort controls', async () => {
+    renderWithProviders(<PreprintListPage />, {
+      initialEntries: ['/preprints?zone=septic'],
+      routes: [{ path: '/preprints', element: <PreprintListPage /> }],
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('combobox')).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole('combobox')).toHaveClass('px-1', 'py-[6px]', 'md:px-3', 'md:py-1.5');
+    expect(screen.getByRole('button', { name: 'Newest / 最新' })).toHaveClass(
+      'px-1',
+      'py-[6px]',
+      'md:px-3',
+      'md:py-1.5',
+    );
+  });
 });

--- a/src/pages/preprints/PreprintListPage.tsx
+++ b/src/pages/preprints/PreprintListPage.tsx
@@ -138,7 +138,7 @@ export const PreprintListPage: React.FC = () => {
   // 🔥 下面的 UI 渲染部分一字不差全部保留！这就是前后端解耦的魅力！
   // ---------------------------------------------------------
   return (
-    <div className="max-w-4xl mx-auto px-4 lg:px-8 py-12">
+    <div className="max-w-4xl mx-auto px-2 lg:px-8 py-6">
       {/* Header */}
       <div className="mb-8">
         <h2 className="text-3xl font-serif font-bold mb-1">
@@ -197,7 +197,7 @@ export const PreprintListPage: React.FC = () => {
         <select
           value={discipline}
           onChange={e => setParam('discipline', e.target.value)}
-          className="border border-gray-300 px-3 py-1.5 text-sm focus:outline-none focus:border-accent-gold bg-white cursor-pointer"
+          className="border border-gray-300 px-1 py-[6px] md:px-3 md:py-1.5 text-sm focus:outline-none focus:border-accent-gold bg-white cursor-pointer"
         >
           {DISCIPLINES.map(d => (
             <option key={d.value} value={d.value}>{d.cn} / {d.en}</option>
@@ -213,7 +213,7 @@ export const PreprintListPage: React.FC = () => {
             <button
               key={opt.value}
               onClick={() => setParam('sort', opt.value)}
-              className={`px-3 py-1.5 text-[10px] font-bold uppercase tracking-widest border transition-colors cursor-pointer ${
+              className={`px-1 py-[6px] md:px-3 md:py-1.5 text-[10px] font-bold uppercase tracking-widest border transition-colors cursor-pointer ${
                 sort === opt.value
                   ? 'border-accent-gold text-accent-gold bg-yellow-50'
                   : 'border-gray-300 text-gray-400 hover:border-accent-gold hover:text-accent-gold'


### PR DESCRIPTION
## 变更概述

  本 PR 主要修复了论文列表页、移动端样式和用户须知弹窗中的一组交互与展示问题，并清理了不应进入仓库的 Cypress 官方示例文件。

  ## 主要改动

  ### 1. 修复论文列表长标题显示问题
  - 为标题增加原生 `title` 属性，鼠标悬浮时可查看完整论文标题

  ### 2. 优化移动端发酵区样式
  - 调整预印本列表页筛选区在移动端的内边距表现
  - 收紧列表页与详情页主容器在移动端的外边距与上下留白
  - 微调 footer 与页面内容间距，改善移动端整体节奏

  ### 3. 修复用户须知弹窗问题
  - 修复未同意状态下无法正常查看《用户协议》与《隐私政策》的问题
  - 在 `/terms` 和 `/privacy` 页面不再显示用户须知遮罩
  - 保留协议链接新开标签页逻辑
  - 修复移动端点击协议链接需要点击两次的问题
  - 优化协议说明行 hover 逻辑：
    - 协议链接保持独立 hover
    - 非链接文案区域联动高亮，交互更一致

  ### 4. 清理 Cypress 示例文件
  - 删除 Cypress 自动生成的官方 E2E 示例文件
  - 回退对应的示例 E2E 配置
  - 在 `.gitignore` 中补充忽略规则，防止这类示例文件后续误入 Git

  ## 测试

  已执行：
  - `npm run test:unit:run -- src/pages/preprints/PreprintCard.test.tsx`
  - `npm run test:unit:run -- src/pages/preprints/PreprintListPage.test.tsx`
  - `npm run test:unit:run -- src/components/layout/CookieConsent.test.tsx`
  - `npm run test:ct:run -- --spec cypress/component/PreprintCard.cy.tsx`

  ## 影响范围

  主要涉及：
  - 论文列表页与详情页样式
  - 用户须知弹窗交互
  - 标题长文本展示
  - Cypress 测试目录清理
