### PR TITLE
fix: 兼容真实接口并修复仪表盘与搜索页

### DIFF
--- a/doc/FRONTEND_REAL_API_FIXES_2026-03-09.md
+++ b/doc/FRONTEND_REAL_API_FIXES_2026-03-09.md
@@ -1,0 +1,144 @@
+# 前端真实接口联调修复记录（2026-03-09）
+
+本文档记录 2026-03-09 围绕“切换真实接口后联调异常”的前端修复，重点覆盖作者仪表盘与搜索页两个受影响区域。
+
+## 1. 本次修复范围
+
+本轮修复包含以下问题：
+
+- 本地开发环境仍在使用 `MSW`，未真正联调线上接口
+- 搜索页请求真实接口时，`limit` 超过后端允许上限，返回 `422`
+- 仪表盘“我的评价”在真实接口下无法正常显示
+- 本地 `MSW` 与真实接口在文章列表字段上存在差异，容易掩盖联调问题
+
+## 2. 真实接口切换
+
+本地联调已改为默认走真实接口：
+
+- 本地 `.env.local` 改为 `VITE_ENABLE_MSW=false`
+- `VITE_API_BASE_URL` 仍指向 `https://api.shitjournal.org`
+
+说明：
+
+- 该环境文件通常不提交到仓库，但本次联调过程中已按真实接口模式验证本地行为
+- 若后续需要切回 Mock，只需把 `VITE_ENABLE_MSW` 再改回 `true`
+
+## 3. 搜索页修复
+
+### 3.1 问题原因
+
+搜索页原先为了前端分页体验，固定以较大的抓取上限请求搜索接口；但真实后端的 `/api/search/article` 对 `limit` 有严格校验，上限为 `30`。因此切到真实接口后，会直接报：
+
+- `Input should be less than or equal to 30`
+
+### 3.2 修复内容
+
+- 在搜索模块中增加统一常量 `SEARCH_API_MAX_LIMIT = 30`
+- 搜索页改为使用该常量，不再直接请求 `100`
+- API 层对搜索请求增加 clamp 逻辑，即使其他页面错误传入更大的 `limit`，也会自动收敛到后端允许范围
+
+涉及文件：
+
+- `src/lib/search.ts`
+- `src/lib/api.ts`
+- `src/pages/SearchPage.tsx`
+
+### 3.3 回归测试
+
+新增搜索页回归测试，模拟真实后端在 `limit > 30` 时返回 `422`，确保前端不会再触发该错误。
+
+涉及文件：
+
+- `src/pages/SearchPage.test.tsx`
+
+## 4. 仪表盘“我的评价”修复
+
+### 4.1 问题原因
+
+“我的评价”并非简单的请求失败，而是**真实接口返回结构与前端此前只兼容的 mock 结构不一致**。
+
+此前前端主要只兼容以下几类列表响应键：
+
+- `data`
+- `items`
+- `articles`
+
+但真实接口可能返回：
+
+- `ratings`
+- `rated_articles`
+- `results`
+- 或者每条记录为 `{ article: {...}, score, created_at }` 这种带嵌套文章对象的形态
+
+在这种情况下，前端会把接口结果错误地解读为空数组，于是页面直接落入：
+
+- `No rated articles yet. / 还没有评价过文章`
+
+### 4.2 修复内容
+
+在 API 层新增“我的评价”响应标准化逻辑：
+
+- 兼容 `ratings`、`rated_articles`、`results` 等多种根键
+- 兼容嵌套结构中的 `article`、`paper`、`manuscript`、`preprint` 等常见字段
+- 从 `score` / `my_score` 中统一提取用户评分
+- 从 `created_at` / `rated_at` / `updated_at` 中统一提取评价时间
+
+同时保留之前的兜底能力：
+
+- 若 `/api/users/me/ratings` 缺失或返回 `404/405`，仍可退回到公开分区列表，按 `my_score` 聚合用户已评价文章
+
+此外，对仪表盘页补充了显式错误态，避免接口异常时静默显示空白结果。
+
+涉及文件：
+
+- `src/lib/api.ts`
+- `src/pages/dashboard/AuthorDashboard.tsx`
+
+### 4.3 回归测试
+
+围绕“我的评价”补充了两类回归测试：
+
+- 当 `/api/users/me/ratings` 不存在时，能回退到公开文章列表聚合显示
+- 当接口返回 `ratings: [{ article, score }]` 这类真实包装结构时，仍能正常展示评价列表
+
+涉及文件：
+
+- `src/pages/dashboard/AuthorDashboard.test.tsx`
+
+## 5. Mock 对齐修复
+
+为了避免本地 Mock 再次掩盖真实接口问题，对 `MSW` 的文章列表 mock 做了同步修正：
+
+- `/api/articles/` 在已登录状态下也会返回当前用户的 `my_score`
+
+这样本地组件测试和真实后端在关键字段上更一致。
+
+涉及文件：
+
+- `src/mocks/handlers.ts`
+
+## 6. 验证结果
+
+已完成以下验证：
+
+- `npm run test:unit:run -- src/pages/SearchPage.test.tsx`
+- `npm run test:unit:run -- src/pages/dashboard/AuthorDashboard.test.tsx`
+- `npm run test:unit:run`
+- `npm run build`
+
+当前结果：
+
+- 单元测试全部通过
+- 构建通过
+
+## 7. 结论
+
+本轮问题的本质不是单点 bug，而是 **Mock 结构、真实接口结构、前端解包逻辑三者不一致** 导致的联调偏差。
+
+修复后：
+
+- 搜索页已兼容真实后端的 `limit` 约束
+- 仪表盘“我的评价”已兼容真实接口常见返回结构
+- Mock 与真实接口关键字段差异已收敛
+
+如果后续后端再稳定发布收藏接口，建议按同样方式补齐“我的收藏”的真实响应兼容层与回归测试。

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,8 +1,131 @@
 // src/lib/api.ts
 import type { SearchArticleItem, SearchScope } from './search';
-import { TAG_SEARCH_ALIASES, normalizeSearchKeyword } from './search';
+import { SEARCH_API_MAX_LIMIT, TAG_SEARCH_ALIASES, normalizeSearchKeyword } from './search';
 
 export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL?.trim() || 'https://api.shitjournal.org';
+
+type ApiError = Error & {
+  status?: number;
+  data?: any;
+};
+
+const DASHBOARD_VISIBLE_ZONES = ['latrine', 'septic', 'stone', 'sediment'] as const;
+const DASHBOARD_VISIBLE_ZONE_SORT: Record<(typeof DASHBOARD_VISIBLE_ZONES)[number], string> = {
+  latrine: 'newest',
+  septic: 'newest',
+  stone: 'highest_rated',
+  sediment: 'newest',
+};
+const DASHBOARD_ZONE_PAGE_SIZE = 50;
+
+function normalizeCollectionResponse(response: any) {
+  if (Array.isArray(response)) return response;
+  return response?.data || response?.items || response?.articles || [];
+}
+
+function normalizeRatedArticleItem(item: any) {
+  if (!item) return null;
+
+  const article = item.article || item.paper || item.manuscript || item.article_data || item.preprint || null;
+  const flattened = article ? { ...article, ...item } : item;
+  const normalized = {
+    ...flattened,
+    id: flattened.id || article?.id || flattened.article_id,
+    title: flattened.title || article?.title || flattened.article_title,
+    tag: flattened.tag || article?.tag,
+    status: flattened.status || article?.status || 'passed',
+    topic: flattened.topic ?? article?.topic ?? null,
+    created_at: flattened.created_at || article?.created_at,
+    rated_at: flattened.rated_at || item.rated_at || item.created_at || item.updated_at || null,
+    my_score: flattened.my_score ?? item.my_score ?? item.score ?? article?.my_score ?? null,
+    author: flattened.author || article?.author || null,
+  };
+
+  return normalized.id ? normalized : null;
+}
+
+function normalizeRatedArticlesResponse(response: any) {
+  const candidates = Array.isArray(response)
+    ? response
+    : response?.ratings
+      || response?.rated_articles
+      || response?.results
+      || response?.data?.ratings
+      || response?.data?.rated_articles
+      || response?.data?.results
+      || response?.data
+      || response?.items
+      || response?.articles
+      || [];
+
+  if (!Array.isArray(candidates)) return [];
+
+  return candidates
+    .map(normalizeRatedArticleItem)
+    .filter(Boolean);
+}
+
+function dedupeItemsById<T extends { id: string }>(items: T[]) {
+  return items.filter((item, index, collection) => collection.findIndex(candidate => candidate.id === item.id) === index);
+}
+
+async function fetchVisibleZonePage(zone: (typeof DASHBOARD_VISIBLE_ZONES)[number], page: number) {
+  const params = new URLSearchParams({
+    zone,
+    sort: DASHBOARD_VISIBLE_ZONE_SORT[zone],
+    discipline: 'all',
+    page: String(page),
+    limit: String(DASHBOARD_ZONE_PAGE_SIZE),
+  });
+
+  return fetchAPI(`/api/articles/?${params.toString()}`);
+}
+
+async function fetchAllVisibleZoneArticles(zone: (typeof DASHBOARD_VISIBLE_ZONES)[number]) {
+  const firstPageResponse = await fetchVisibleZonePage(zone, 1);
+  const firstPageItems = normalizeCollectionResponse(firstPageResponse);
+  const totalCount = Number(firstPageResponse?.count || firstPageResponse?.total || firstPageItems.length || 0);
+  const totalPages = Math.max(1, Math.ceil(totalCount / DASHBOARD_ZONE_PAGE_SIZE));
+
+  if (totalPages === 1) {
+    return firstPageItems;
+  }
+
+  const remainingResponses = await Promise.all(
+    Array.from({ length: totalPages - 1 }, (_, pageIndex) => fetchVisibleZonePage(zone, pageIndex + 2)),
+  );
+
+  return [
+    ...firstPageItems,
+    ...remainingResponses.flatMap(response => normalizeCollectionResponse(response)),
+  ];
+}
+
+async function fetchRatedArticlesFromVisibleZones() {
+  const visibleZoneArticles = await Promise.all(
+    DASHBOARD_VISIBLE_ZONES.map(zone => fetchAllVisibleZoneArticles(zone)),
+  );
+
+  return dedupeItemsById(
+    visibleZoneArticles
+      .flat()
+      .filter(article => Number.isFinite(Number(article?.my_score)) && Number(article.my_score) > 0),
+  ).sort((left, right) => {
+    const rightScore = Number(right?.my_score || 0);
+    const leftScore = Number(left?.my_score || 0);
+
+    if (rightScore !== leftScore) {
+      return rightScore - leftScore;
+    }
+
+    return String(right?.created_at || '').localeCompare(String(left?.created_at || ''));
+  });
+}
+
+function isMissingEndpointError(error: unknown) {
+  const status = (error as ApiError | undefined)?.status;
+  return status === 404 || status === 405;
+}
 
 /**
  * 核心拦截器：所有请求都要经过这个管道
@@ -43,8 +166,11 @@ async function fetchAPI(endpoint: string, options: RequestInit = {}) {
     const errorMsg = errorData.detail 
       ? (typeof errorData.detail === 'string' ? errorData.detail : errorData.detail[0]?.msg)
       : '服务器开小差了，请稍后再试';
-      
-    throw new Error(errorMsg);
+
+    const error = new Error(errorMsg) as ApiError;
+    error.status = response.status;
+    error.data = errorData;
+    throw error;
   }
 
   return response.json();
@@ -233,15 +359,23 @@ export const API = {
     },
     getMyArticles: async () => {
       const res = await fetchAPI('/api/users/me/articles');
-      return res.data || res.items || res.articles || res;
+      return normalizeCollectionResponse(res);
     },
     getMyFavorites: async () => {
       const res = await fetchAPI('/api/users/me/favorites');
-      return res.data || res.items || res.articles || res;
+      return normalizeCollectionResponse(res);
     },
     getMyRatedArticles: async () => {
-      const res = await fetchAPI('/api/users/me/ratings');
-      return res.data || res.items || res.articles || res;
+      try {
+        const res = await fetchAPI('/api/users/me/ratings');
+        return normalizeRatedArticlesResponse(res);
+      } catch (error) {
+        if (!isMissingEndpointError(error)) {
+          throw error;
+        }
+
+        return fetchRatedArticlesFromVisibleZones();
+      }
     },
     updateProfile: async (displayName?: string, avatarUrl?: string, institution?: string, socialMedia?: string) => {
       const res = await fetchAPI('/api/users/me', {
@@ -294,12 +428,13 @@ export const API = {
     articles: async (query: string, scope: SearchScope = 'anywhere', limit = 10) => {
       const trimmed = query.trim();
       if (!trimmed) return { data: [] };
+      const normalizedLimit = Math.max(1, Math.min(limit, SEARCH_API_MAX_LIMIT));
 
       const request = async (type: 'article' | 'author') => {
         const params = new URLSearchParams({
           q: trimmed,
           type,
-          limit: String(limit),
+          limit: String(normalizedLimit),
         });
 
         const response = await fetchAPI(`/api/search/article?${params.toString()}`);
@@ -323,7 +458,7 @@ export const API = {
             }),
         )
           .sort((left, right) => right.created_at.localeCompare(left.created_at))
-          .slice(0, limit);
+          .slice(0, normalizedLimit);
       };
 
       if (scope === 'tag') {
@@ -341,7 +476,7 @@ export const API = {
 
       const deduped = dedupeSearchItems([...articleResults, ...authorResults])
         .sort((left, right) => right.created_at.localeCompare(left.created_at))
-        .slice(0, limit);
+        .slice(0, normalizedLimit);
 
       return { data: deduped };
     },

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -1,5 +1,7 @@
 export type SearchScope = 'anywhere' | 'article' | 'author' | 'tag';
 
+export const SEARCH_API_MAX_LIMIT = 30;
+
 export interface SearchArticleItem {
   id: string;
   title: string;

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -330,6 +330,7 @@ export const handlers = [
   http.get('*/api/articles/', async ({ request }) => {
     await delay(MOCK_DELAY_MS);
     const url = new URL(request.url);
+    const user = getUserFromAuth(request);
     const zone = url.searchParams.get('zone') ?? 'latrine';
     const sort = url.searchParams.get('sort') ?? 'newest';
     const discipline = url.searchParams.get('discipline') ?? 'all';
@@ -345,7 +346,7 @@ export const handlers = [
     );
 
     return json({
-      data: paginate(filtered.map(articleForResponse), page, limit),
+      data: paginate(filtered.map(article => articleForResponse(article, user)), page, limit),
       count: filtered.length,
       total: filtered.length,
     });

--- a/src/pages/SearchPage.test.tsx
+++ b/src/pages/SearchPage.test.tsx
@@ -1,6 +1,8 @@
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '../mocks/node';
 import { renderWithProviders } from '../test/renderWithProviders';
 import { SearchPage } from './SearchPage';
 
@@ -39,6 +41,51 @@ describe('SearchPage', () => {
     });
 
     expect(screen.getByText(/范围 作者昵称/)).toBeInTheDocument();
+  });
+
+  it('caps the live search request limit at the backend maximum', async () => {
+    server.use(
+      http.get('*/api/search/article', async ({ request }) => {
+        const url = new URL(request.url);
+        const limit = Number(url.searchParams.get('limit') ?? '0');
+
+        if (limit > 30) {
+          return HttpResponse.json({ detail: 'Input should be less than or equal to 30' }, { status: 422 });
+        }
+
+        return HttpResponse.json({
+          data: [
+            {
+              id: 'limit-check-result',
+              title: 'Limit Clamp Result',
+              tag: 'hardcore',
+              zones: 'latrine',
+              status: 'passed',
+              discipline: 'engineering',
+              created_at: '2026-03-09T00:00:00.000Z',
+              rating_count: 0,
+              avg_score: 0,
+              weighted_score: 0,
+              author: {
+                display_name: 'Clamp Tester',
+                institution: 'API Contract Lab',
+              },
+            },
+          ],
+        });
+      }),
+    );
+
+    renderWithProviders(<SearchPage />, {
+      initialEntries: ['/search?q=Clamp&type=article'],
+      routes: [{ path: '/search', element: <SearchPage /> }],
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Limit Clamp Result')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('Input should be less than or equal to 30')).not.toBeInTheDocument();
   });
 
   it('supports tag search for meme and hardcore chips', async () => {

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -2,11 +2,11 @@ import React, { useEffect, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { ZONE_LABELS } from '../lib/constants';
 import { API } from '../lib/api';
-import { QUICK_TAG_SEARCHES, SEARCH_SCOPE_OPTIONS, type SearchArticleItem, type SearchScope, createSearchParams } from '../lib/search';
+import { QUICK_TAG_SEARCHES, SEARCH_API_MAX_LIMIT, SEARCH_SCOPE_OPTIONS, type SearchArticleItem, type SearchScope, createSearchParams } from '../lib/search';
 import { PreprintCard } from './preprints/PreprintCard';
 
 const PAGE_SIZE = 10;
-const SEARCH_FETCH_LIMIT = 100;
+const SEARCH_FETCH_LIMIT = SEARCH_API_MAX_LIMIT;
 
 export const SearchPage: React.FC = () => {
   const [searchParams, setSearchParams] = useSearchParams();

--- a/src/pages/dashboard/AuthorDashboard.test.tsx
+++ b/src/pages/dashboard/AuthorDashboard.test.tsx
@@ -1,7 +1,9 @@
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it } from 'vitest';
+import { http, HttpResponse } from 'msw';
 import { API } from '../../lib/api';
+import { server } from '../../mocks/node';
 import { renderWithProviders } from '../../test/renderWithProviders';
 import { AuthorDashboard } from './AuthorDashboard';
 
@@ -35,6 +37,78 @@ describe('AuthorDashboard', () => {
       expect(screen.getByText('Benchmarking Latrine Throughput Under Conference Deadline Stress')).toBeInTheDocument();
     });
 
+    expect(screen.getAllByText('Rated 5/5 / 已评价 5/5').length).toBeGreaterThan(0);
+  });
+
+  it('falls back to visible zone articles when the ratings endpoint is unavailable', async () => {
+    server.use(
+      http.get('*/api/users/me/ratings', async () => HttpResponse.json({ detail: 'Not Found' }, { status: 404 })),
+    );
+
+    await loginAsReader();
+    const user = userEvent.setup();
+
+    renderWithProviders(<AuthorDashboard />, {
+      initialEntries: ['/dashboard'],
+      routes: [{ path: '/dashboard', element: <AuthorDashboard /> }],
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('My Excretions')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Rated / 我的评价' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Benchmarking Latrine Throughput Under Conference Deadline Stress')).toBeInTheDocument();
+    });
+
+    expect(screen.getAllByText('Rated 5/5 / 已评价 5/5').length).toBeGreaterThan(0);
+  });
+
+  it('renders rated articles when the live endpoint returns a ratings wrapper payload', async () => {
+    server.use(
+      http.get('*/api/users/me/ratings', async () => HttpResponse.json({
+        ratings: [
+          {
+            score: 5,
+            created_at: '2026-03-09T00:00:00.000Z',
+            article: {
+              id: 'rated-live-shape-1',
+              title: 'Live Ratings Payload Compatibility Check',
+              tag: 'hardcore',
+              status: 'passed',
+              created_at: '2026-03-08T00:00:00.000Z',
+              topic: 'compat',
+              author: {
+                display_name: 'Compat Author',
+                institution: 'API Contract Lab',
+              },
+            },
+          },
+        ],
+      })),
+    );
+
+    await loginAsReader();
+    const user = userEvent.setup();
+
+    renderWithProviders(<AuthorDashboard />, {
+      initialEntries: ['/dashboard'],
+      routes: [{ path: '/dashboard', element: <AuthorDashboard /> }],
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('My Excretions')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Rated / 我的评价' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Live Ratings Payload Compatibility Check')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Compat Author · API Contract Lab')).toBeInTheDocument();
     expect(screen.getAllByText('Rated 5/5 / 已评价 5/5').length).toBeGreaterThan(0);
   });
 });

--- a/src/pages/dashboard/AuthorDashboard.tsx
+++ b/src/pages/dashboard/AuthorDashboard.tsx
@@ -91,23 +91,26 @@ export const AuthorDashboard: React.FC = () => {
   const [ratedArticles, setRatedArticles] = useState<DashboardArticle[]>([]);
   const [activeTab, setActiveTab] = useState<DashboardTab>('submissions');
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState('');
 
   useEffect(() => {
     if (!user) return;
 
     const fetchDashboardData = async () => {
       setLoading(true);
+      setLoadError('');
       try {
         const [submissionResponse, ratedResponse] = await Promise.all([
           API.users.getMyArticles(),
           API.users.getMyRatedArticles(),
         ]);
 
-        setSubmissions(submissionResponse.articles || submissionResponse.data || submissionResponse || []);
+        setSubmissions(Array.isArray(submissionResponse) ? submissionResponse : []);
         setFavorites([]);
-        setRatedArticles(ratedResponse.articles || ratedResponse.data || ratedResponse || []);
+        setRatedArticles(Array.isArray(ratedResponse) ? ratedResponse : []);
       } catch (error) {
         console.error('拉取仪表盘数据失败:', error);
+        setLoadError(error instanceof Error ? error.message : '加载失败，请稍后再试');
       } finally {
         setLoading(false);
       }
@@ -169,6 +172,11 @@ export const AuthorDashboard: React.FC = () => {
           {loading ? (
             <div className="text-center py-20">
               <img src="/LOGO2.png" alt="Loading" className="w-9 h-9 animate-pulse inline-block" />
+            </div>
+          ) : loadError ? (
+            <div className="border border-red-200 bg-red-50 px-6 py-10 text-center">
+              <p className="font-serif text-lg text-red-700 mb-2">Dashboard unavailable</p>
+              <p className="chinese-serif text-red-600">{loadError}</p>
             </div>
           ) : currentItems.length === 0 ? (
             <div className="text-center py-20 bg-white border border-gray-200">


### PR DESCRIPTION
## 变更摘要

  本次修复主要解决切换真实接口后前端联调出现的两类问题：

  1. 搜索页请求真实接口时，`limit` 超过后端允许上限，导致返回 `422`
  2. 作者仪表盘“我的评价”在真实接口下无法正常显示，页面误判为空列表

  同时补充了今日联调工作的中文文档记录，方便后续追踪。

  ## 具体修改

  ### 1. 搜索页兼容真实接口限制

  - 在搜索模块中新增统一常量 `SEARCH_API_MAX_LIMIT = 30`
  - 搜索页不再固定请求 `100` 条结果
  - API 层对搜索请求增加 clamp 逻辑，避免其他页面错误传入超过后端上限的 `limit`
  - 补充搜索页回归测试，确保不会再触发 `Input should be less than or equal to 30`

  ### 2. 仪表盘“我的评价”修复

  - 保留 `/api/users/me/ratings` 的调用
  - 新增真实接口响应兼容层，支持以下常见返回结构：
    - `ratings`
    - `rated_articles`
    - `results`
    - `[{ article, score, created_at }]`
  - 统一提取：
    - `id`
    - `title`
    - `tag`
    - `status`
    - `topic`
    - `created_at`
    - `rated_at`
    - `my_score`
    - `author`
  - 如果 `/api/users/me/ratings` 不存在或返回 `404/405`，仍可回退到公开分区列表，基于 `my_score` 聚合已评价文章
  - 仪表盘补充显式错误态，避免接口异常时静默显示空白

  ### 3. Mock 与真实接口对齐

  - 修正 `MSW` 的 `/api/articles/` mock
  - 已登录状态下也会返回当前用户的 `my_score`
  - 降低 Mock 掩盖真实联调问题的风险

  ### 4. 文档补充

  - 新增今日联调修复记录：
    - `doc/FRONTEND_REAL_API_FIXES_2026-03-09.md`

  ## 验证结果

  已完成以下验证：

  - `npm run test:unit:run -- src/pages/SearchPage.test.tsx`
  - `npm run test:unit:run -- src/pages/dashboard/AuthorDashboard.test.tsx`
  - `npm run test:unit:run`
  - `npm run build`

  结果：

  - 单元测试全部通过
  - 构建通过

  ## 影响文件

  - `src/lib/api.ts`
  - `src/lib/search.ts`
  - `src/pages/SearchPage.tsx`
  - `src/pages/SearchPage.test.tsx`
  - `src/pages/dashboard/AuthorDashboard.tsx`
  - `src/pages/dashboard/AuthorDashboard.test.tsx`
  - `src/mocks/handlers.ts`
  - `doc/FRONTEND_REAL_API_FIXES_2026-03-09.md`